### PR TITLE
Migrate to modern Python bs4 API

### DIFF
--- a/agent_as_a_judge/module/read.py
+++ b/agent_as_a_judge/module/read.py
@@ -252,7 +252,7 @@ class DevRead:
             with open(file_path, "r", encoding="utf-8") as f:
                 data = markdown.markdown(f.read())
                 return (
-                    "".join(BeautifulSoup(data, "html.parser").findAll(string=True)),
+                    "".join(BeautifulSoup(data, "html.parser").find_all(string=True)),
                     None,
                 )
         except Exception as e:


### PR DESCRIPTION
# PR Summary
This PR resolves the deprecation warnings of the `bs4` library:
```python
DeprecationWarning: Call to deprecated method findAll. (Replaced by find_all) -- Deprecated since version 4.0.0.
```